### PR TITLE
[#94218282] add queued_at to header

### DIFF
--- a/lib/worker_roulette/foreman.rb
+++ b/lib/worker_roulette/foreman.rb
@@ -1,6 +1,10 @@
+require_relative "preprocessor"
+
 module WorkerRoulette
   class Foreman
-    attr_reader :sender, :namespace, :channel
+    include Preprocessor
+
+    attr_reader :sender, :namespace, :channel, :preprocessors
 
     LUA_ENQUEUE_WORK_ORDERS = <<-HERE
       local counter_key       = KEYS[1]
@@ -32,12 +36,13 @@ module WorkerRoulette
       enqueue_work_orders(work_order, job_notification)
     HERE
 
-    def initialize(redis_pool, sender, namespace = nil)
-      @redis_pool = redis_pool
-      @sender     = sender
-      @namespace  = namespace
-      @channel    = namespace || WorkerRoulette::JOB_NOTIFICATIONS
-      @lua        = Lua.new(@redis_pool)
+    def initialize(redis_pool, sender, namespace = nil, preprocessors = [])
+      @redis_pool    = redis_pool
+      @sender        = sender
+      @preprocessors = preprocessors
+      @namespace     = namespace
+      @channel       = namespace || WorkerRoulette::JOB_NOTIFICATIONS
+      @lua           = Lua.new(@redis_pool)
     end
 
     def enqueue_work_order(work_order, headers = {}, &callback)
@@ -47,7 +52,7 @@ module WorkerRoulette
 
     def enqueue(work_order, &callback)
       @lua.call(LUA_ENQUEUE_WORK_ORDERS, [counter_key, job_board_key, sender_key, @channel],
-                [WorkerRoulette.dump(work_order),  WorkerRoulette::JOB_NOTIFICATIONS], &callback)
+                [WorkerRoulette.dump(preprocess(work_order, channel)),  WorkerRoulette::JOB_NOTIFICATIONS], &callback)
     end
 
     def job_board_key

--- a/lib/worker_roulette/foreman.rb
+++ b/lib/worker_roulette/foreman.rb
@@ -70,7 +70,7 @@ module WorkerRoulette
     private
 
     def default_headers
-      { "sender" => sender, "queued_at" => (Time.now.to_f * 1000000).to_i }
+      { "sender" => sender }
     end
 
   end

--- a/lib/worker_roulette/foreman.rb
+++ b/lib/worker_roulette/foreman.rb
@@ -65,7 +65,7 @@ module WorkerRoulette
     private
 
     def default_headers
-      { "sender" => sender, "queued_at" => Time.now.nsec.to_s }
+      { "sender" => sender, "queued_at" => (Time.now.to_f * 1000000).to_i }
     end
 
   end

--- a/lib/worker_roulette/preprocessor.rb
+++ b/lib/worker_roulette/preprocessor.rb
@@ -1,0 +1,15 @@
+module WorkerRoulette
+  module Preprocessor
+    def preprocess(work_order, channel)
+      return work_order unless preprocessors.any?
+
+      class_name = self.class.name.split(/::/).last
+
+      preprocessors.inject(work_order) do |job, processor_module|
+        processor_class = processor_module.const_get(class_name)
+        processor = processor_class.new
+        processor.process(job, channel)
+      end
+    end
+  end
+end

--- a/lib/worker_roulette/queue_latency_tracker.rb
+++ b/lib/worker_roulette/queue_latency_tracker.rb
@@ -2,7 +2,7 @@ module QueueLatencyTracker
   GRANULARITY = 1_000_000
 
   class Foreman
-    def process(work_order)
+    def process(work_order, _channel)
       work_order['headers'].merge!("queued_at" => (Time.now.to_f * GRANULARITY).to_i)
       work_order
     end

--- a/lib/worker_roulette/queue_latency_tracker.rb
+++ b/lib/worker_roulette/queue_latency_tracker.rb
@@ -1,0 +1,47 @@
+module QueueLatencyTracker
+  GRANULARITY = 1_000_000
+
+  class Foreman
+    def process(work_order)
+      work_order['headers'].merge!("queued_at" => (Time.now.to_f * GRANULARITY).to_i)
+      work_order
+    end
+  end
+
+  class Tradesman
+    def process(work_order, channel)
+      send_latency(work_order["headers"]["queued_at"], channel)
+      work_order
+    end
+
+    def send_latency(queued_at, channel)
+      latency_ns = (Time.now.to_f * GRANULARITY).to_i - queued_at
+      logstash_send(latency_json(latency_ns / 1000.0, channel))
+    end
+
+    def logstash_send(json)
+      UDPSocket.new.send(json, 0, config[:logstash][:server_ip], config[:logstash][:port])
+    end
+
+    def latency_json(latency_ms, channel)
+      %({"server_name":"#{config[:server_name]}","queue_latency (ms)":#{latency_ms},"channel":"#{channel}"})
+    end
+
+    def config
+      QueueLatencyTracker.config
+    end
+  end
+
+  class << self
+    attr_reader :config
+    def configure(config)
+      @config = {
+        logstash: {
+          server_ip: config[:logstash_server_ip],
+          port: config[:logstash_port] },
+        server_name: config[:server_name]
+      }
+    end
+
+  end
+end

--- a/lib/worker_roulette/version.rb
+++ b/lib/worker_roulette/version.rb
@@ -1,3 +1,3 @@
 module WorkerRoulette
-  VERSION = '0.1.12'
+  VERSION = '0.2.0'
 end

--- a/spec/integration/evented_worker_roulette_spec.rb
+++ b/spec/integration/evented_worker_roulette_spec.rb
@@ -7,7 +7,7 @@ module WorkerRoulette
     let(:sender)                            { "katie_80" }
     let(:work_orders)                       { ["hello", "foreman"] }
     let(:queued_at)                         { 1234567 }
-    let(:default_headers)                   { Hash["headers" => { "sender" => sender, "queued_at" => Time.now.to_i }] }
+    let(:default_headers)                   { Hash["headers" => { "sender" => sender, "queued_at" => (queued_at.to_f * 1_000_000).to_i }] }
     let(:hello_work_order)                  { Hash["payload" => "hello"] }
     let(:foreman_work_order)                { Hash["payload" => "foreman"] }
     let(:work_orders_with_headers)          { default_headers.merge({ "payload" => work_orders }) }
@@ -16,7 +16,7 @@ module WorkerRoulette
     let(:redis)                             { Redis.new(worker_roulette.redis_config) }
 
     before do
-      allow_any_instance_of(Time).to receive(:now).and_return(queued_at)
+      allow(Time).to receive(:now).and_return(queued_at)
     end
 
     context "Evented Foreman" do

--- a/spec/integration/evented_worker_roulette_spec.rb
+++ b/spec/integration/evented_worker_roulette_spec.rb
@@ -1,84 +1,90 @@
 require "spec_helper"
+
 module WorkerRoulette
   describe WorkerRoulette do
     include EventedSpec::EMSpec
 
-    let(:sender) {'katie_80'}
-    let(:work_orders) {["hello", "foreman"]}
-    let(:default_headers) {Hash['headers' => {'sender' => sender}]}
-    let(:hello_work_order) {Hash['payload' => "hello"]}
-    let(:foreman_work_order) {Hash['payload' => "foreman"]}
-    let(:work_orders_with_headers) {default_headers.merge({'payload' => work_orders})}
-    let(:jsonized_work_orders_with_headers) {[WorkerRoulette.dump(work_orders_with_headers)]}
-    let(:worker_roulette) { WorkerRoulette.start(evented: true) }
-    let(:redis) {Redis.new(worker_roulette.redis_config)}
+    let(:sender)                            { "katie_80" }
+    let(:work_orders)                       { ["hello", "foreman"] }
+    let(:queued_at)                         { 1234567 }
+    let(:default_headers)                   { Hash["headers" => { "sender" => sender, "queued_at" => Time.now.to_i }] }
+    let(:hello_work_order)                  { Hash["payload" => "hello"] }
+    let(:foreman_work_order)                { Hash["payload" => "foreman"] }
+    let(:work_orders_with_headers)          { default_headers.merge({ "payload" => work_orders }) }
+    let(:jsonized_work_orders_with_headers) { [WorkerRoulette.dump(work_orders_with_headers)] }
+    let(:worker_roulette)                   { WorkerRoulette.start(evented: true) }
+    let(:redis)                             { Redis.new(worker_roulette.redis_config) }
+
+    before do
+      allow_any_instance_of(Time).to receive(:now).and_return(queued_at)
+    end
 
     context "Evented Foreman" do
-      let(:subject) {worker_roulette.foreman(sender)}
+      subject(:foreman) {worker_roulette.foreman(sender)}
 
       it "enqueues work" do
         called = false
-        foreman = worker_roulette.foreman('foreman')
-        foreman.enqueue_work_order('some old fashion work') do |redis_response, stuff|
+        foreman = worker_roulette.foreman("foreman")
+        foreman.enqueue_work_order("some old fashion work") do |redis_response, stuff|
           called = true
         end
         done(0.1) { expect(called).to be_truthy }
       end
 
-      it "should enqueue_work_order two work_orders in the sender's slot in the job board" do
-        subject.enqueue_work_order(work_orders.first) do
-          subject.enqueue_work_order(work_orders.last) do
-            expected = work_orders.map { |m| WorkerRoulette.dump(default_headers.merge({'payload' => m})) }
+      it "enqueues two work_orders in the sender's slot in the job board" do
+        foreman.enqueue_work_order(work_orders.first) do
+          foreman.enqueue_work_order(work_orders.last) do
+            expected = work_orders.map { |m| WorkerRoulette.dump(default_headers.merge({"payload" => m})) }
             expect(redis.lrange(sender, 0, -1)).to eq(expected)
             done
           end
         end
       end
 
-      it "should enqueue_work_order an array of work_orders without headers in the sender's slot in the job board" do
-        subject.enqueue_work_order_without_headers(work_orders) do
+      it "enqueues an array of work_orders without headers in the sender's slot in the job board" do
+        foreman.enqueue(work_orders) do
           expect(redis.lrange(sender, 0, -1)).to eq([WorkerRoulette.dump(work_orders)])
           done
         end
       end
 
-      it "should enqueue_work_order an array of work_orders with default headers in the sender's slot in the job board" do
-        subject.enqueue_work_order(work_orders) do
+      it "enqueues an array of work_orders with default headers in the sender's slot in the job board" do
+        foreman.enqueue_work_order(work_orders) do
           expect(redis.lrange(sender, 0, -1)).to eq(jsonized_work_orders_with_headers)
           done
         end
       end
 
-      it "should enqueue_work_order an array of work_orders with additional headers in the sender's slot in the job board" do
-        extra_headers = {'foo' => 'bars'}
-        subject.enqueue_work_order(work_orders, extra_headers) do
-          work_orders_with_headers['headers'].merge!(extra_headers)
+      it "enqueues an array of work_orders with additional headers in the sender's slot in the job board" do
+        extra_headers = {"foo" => "bars"}
+        foreman.enqueue_work_order(work_orders, extra_headers) do
+          work_orders_with_headers["headers"].merge!(extra_headers)
           expect(redis.lrange(sender, 0, -1)).to eq([WorkerRoulette.dump(work_orders_with_headers)])
           done
         end
       end
 
-      it "should post the sender's id to the job board with an order number" do
-        first_foreman      = worker_roulette.foreman('first_foreman')
-        first_foreman.enqueue_work_order('foo') do
-          subject.enqueue_work_order(work_orders.first) do
-            subject.enqueue_work_order(work_orders.last) do
-              expect(redis.zrange(subject.job_board_key, 0, -1, with_scores: true)).to eq([["first_foreman", 1.0], ["katie_80", 2.0]])
+      it "posts the sender's id to the job board with an order number" do
+        first_foreman      = worker_roulette.foreman("first_foreman")
+        first_foreman.enqueue_work_order("foo") do
+          foreman.enqueue_work_order(work_orders.first) do
+            foreman.enqueue_work_order(work_orders.last) do
+              expect(redis.zrange(foreman.job_board_key, 0, -1, with_scores: true)).to eq([["first_foreman", 1.0], ["katie_80", 2.0]])
               done
             end
           end
         end
       end
 
-      it "should generate a monotically increasing score for senders not on the job board, but not for senders already there" do
-        first_foreman = worker_roulette.foreman('first_foreman')
-        expect(redis.get(subject.counter_key)).to be_nil
+      it "generates a monotically increasing score for senders not on the job board, but not for senders already there" do
+        first_foreman = worker_roulette.foreman("first_foreman")
+        expect(redis.get(foreman.counter_key)).to be_nil
         first_foreman.enqueue_work_order(work_orders.first) do
-          expect(redis.get(subject.counter_key)).to eq("1")
+          expect(redis.get(foreman.counter_key)).to eq("1")
           first_foreman.enqueue_work_order(work_orders.last) do
-            expect(redis.get(subject.counter_key)).to eq("1")
-            subject.enqueue_work_order(work_orders.first) do
-              expect(redis.get(subject.counter_key)).to eq("2")
+            expect(redis.get(foreman.counter_key)).to eq("1")
+            foreman.enqueue_work_order(work_orders.first) do
+              expect(redis.get(foreman.counter_key)).to eq("2")
               done
             end
           end
@@ -87,33 +93,33 @@ module WorkerRoulette
     end
 
     context "Evented Tradesman" do
-      let(:foreman) {worker_roulette.foreman(sender)}
-      let(:subject)  {worker_roulette.tradesman(nil, 0.01) }
+      let(:foreman)       { worker_roulette.foreman(sender) }
+      subject(:tradesman) { worker_roulette.tradesman(nil, 0.01) }
 
-      it "should be working on behalf of a sender" do
+      it "works on behalf of a sender" do
         foreman.enqueue_work_order(work_orders) do
-          subject.work_orders! do |r|
-            expect(subject.last_sender).to eq(sender)
+          tradesman.work_orders! do |r|
+            expect(tradesman.last_sender).to eq(sender)
             done
           end
         end
       end
 
-      it "should remove the lock from the last_sender's queue" do
-        most_recent_sender = 'most_recent_sender'
+      it "removes the lock from the last_sender's queue" do
+        most_recent_sender = "most_recent_sender"
         most_recent_foreman = worker_roulette.foreman(most_recent_sender)
-        other_foreman = worker_roulette.foreman('katie_80')
+        other_foreman = worker_roulette.foreman("katie_80")
 
         other_foreman.enqueue_work_order(work_orders) do
           most_recent_foreman.enqueue_work_order(work_orders) do
             expect(redis.keys("L*:*").length).to eq(0)
-            subject.work_orders! do
+            tradesman.work_orders! do
               expect(redis.get("L*:katie_80")).to eq("1")
               expect(redis.keys("L*:*").length).to eq(1)
-              subject.work_orders! do
+              tradesman.work_orders! do
                 expect(redis.keys("L*:*").length).to eq(1)
                 expect(redis.get("L*:most_recent_sender")).to eq("1")
-                subject.work_orders!
+                tradesman.work_orders!
                 done(0.2) do
                   expect(redis.keys("L*:*").length).to eq(0)
                 end
@@ -123,69 +129,66 @@ module WorkerRoulette
         end
       end
 
-      it "should drain one set of work_orders from the sender's slot in the job board" do
+      it "drains one set of work_orders from the sender's slot in the job board" do
         foreman.enqueue_work_order(work_orders) do
-          subject.work_orders! do |r|
-            expect(r).to eq([work_orders_with_headers])
-            subject.work_orders! do |r| expect(r).to be_empty
-              subject.work_orders! {|r| expect(r).to be_empty; done} #does not throw an error if queue is alreay empty
+          tradesman.work_orders! do |r0|
+            expect(r0).to eq([work_orders_with_headers])
+            tradesman.work_orders! do |r1| expect(r1).to be_empty
+              tradesman.work_orders! {|r2| expect(r2).to be_empty; done} #does not throw an error if queue is alreay empty
             end
           end
         end
       end
 
-      it "should take the oldest sender off the job board (FIFO)" do
+      it "takes the oldest sender off the job board (FIFO)" do
         foreman.enqueue_work_order(work_orders) do
           oldest_sender = sender.to_s
-          most_recent_sender = 'most_recent_sender'
+          most_recent_sender = "most_recent_sender"
           most_recent_foreman = worker_roulette.foreman(most_recent_sender)
           most_recent_foreman.enqueue_work_order(work_orders) do
-            expect(redis.zrange(subject.job_board_key, 0, -1)).to eq([oldest_sender, most_recent_sender])
-            subject.work_orders! { expect(redis.zrange(subject.job_board_key, 0, -1)).to eq([most_recent_sender]); done }
+            expect(redis.zrange(tradesman.job_board_key, 0, -1)).to eq([oldest_sender, most_recent_sender])
+            tradesman.work_orders! { expect(redis.zrange(tradesman.job_board_key, 0, -1)).to eq([most_recent_sender]); done }
           end
         end
       end
 
-      it "should get the work_orders from the next queue when a new job is ready" do
-        #tradesman polls every so often, we care that it is called at least twice, but did not use
-        #the built in rspec syntax for that bc if the test ends while we're talking to redis, redis
-        #throws an Error. This way we ensure we call work_orders! at least twice and just stub the second
-        #call so as not to hurt redis' feelings.
+      it "gets the work_orders from the next queue when a new job is ready" do
+        # tradesman polls every so often, we care that it is called at least twice, but did not use
+        # the built in rspec syntax for that bc if the test ends while we"re talking to redis, redis
+        # throws an Error. This way we ensure we call work_orders! at least twice and just stub the second
+        # call so as not to hurt redis" feelings.
 
-        expect(subject).to receive(:work_orders!).and_call_original
-        expect(subject).to receive(:work_orders!)
+        expect(tradesman).to receive(:work_orders!).and_call_original
+        expect(tradesman).to receive(:work_orders!)
 
         foreman.enqueue_work_order(work_orders) do
-          subject.wait_for_work_orders do |redis_work_orders|
+          tradesman.wait_for_work_orders do |redis_work_orders|
             expect(redis_work_orders).to eq([work_orders_with_headers])
-            expect(subject.last_sender).to match(/katie_80/)
+            expect(tradesman.last_sender).to match(/katie_80/)
             done(0.1)
           end
         end
       end
 
-      it "should publish and subscribe on custom channels" do
-        good_subscribed   = false
-        bad_subscribed    = false
+      it "publishes and subscribes on custom channels" do
+        tradesman         = worker_roulette.tradesman("good_channel", 0.001)
+        evil_tradesman    = worker_roulette.tradesman("bad_channel", 0.001)
 
-        tradesman         = worker_roulette.tradesman('good_channel', 0.001)
-        evil_tradesman    = worker_roulette.tradesman('bad_channel', 0.001)
+        good_foreman      = worker_roulette.foreman("foreman", "good_channel")
+        bad_foreman       = worker_roulette.foreman("foreman", "bad_channel")
 
-        good_foreman      = worker_roulette.foreman('foreman', 'good_channel')
-        bad_foreman       = worker_roulette.foreman('foreman', 'bad_channel')
-
-        #tradesman polls every so often, we care that it is called at least twice, but did not use
-        #the built in rspec syntax for that bc if the test ends while we're talking to redis, redis
-        #throws an Error. This way we ensure we call work_orders! at least twice and just stub the second
-        #call so as not to hurt redis' feelings.
+        # tradesman polls every so often, we care that it is called at least twice, but did not use
+        # the built in rspec syntax for that bc if the test ends while we"re talking to redis, redis
+        # throws an Error. This way we ensure we call work_orders! at least twice and just stub the second
+        # call so as not to hurt redis" feelings.
         expect(tradesman).to       receive(:work_orders!).and_call_original
         expect(tradesman).to       receive(:work_orders!)
 
         expect(evil_tradesman).to  receive(:work_orders!).and_call_original
         expect(evil_tradesman).to  receive(:work_orders!)
 
-        good_foreman.enqueue_work_order('some old fashion work') do
-          bad_foreman.enqueue_work_order('evil biddings you should not carry out') do
+        good_foreman.enqueue_work_order("some old fashion work") do
+          bad_foreman.enqueue_work_order("evil biddings you should not carry out") do
 
             tradesman.wait_for_work_orders do |good_work|
               expect(good_work.to_s).to match("old fashion")
@@ -202,24 +205,24 @@ module WorkerRoulette
         end
       end
 
-      it "should pull off work orders for more than one sender" do
-        tradesman = worker_roulette.tradesman('good_channel')
+      it "extracts work orders for more than one sender" do
+        tradesman = worker_roulette.tradesman("good_channel")
 
-        good_foreman = worker_roulette.foreman('good_foreman', 'good_channel')
-        lazy_foreman = worker_roulette.foreman('lazy_foreman', 'good_channel')
+        good_foreman = worker_roulette.foreman("good_foreman", "good_channel")
+        lazy_foreman = worker_roulette.foreman("lazy_foreman", "good_channel")
 
         got_good = false
         got_lazy  = false
-        good_foreman.enqueue_work_order('do good work') do
+        good_foreman.enqueue_work_order("do good work") do
           tradesman.work_orders! do |r|
             got_good = true
-            expect(r.first['payload']).to eq('do good work')
+            expect(r.first["payload"]).to eq("do good work")
           end
         end
-        lazy_foreman.enqueue_work_order('just get it done') do
+        lazy_foreman.enqueue_work_order("just get it done") do
           tradesman.work_orders! do |r|
             got_lazy = true
-            expect(r.first['payload']).to eq('just get it done')
+            expect(r.first["payload"]).to eq("just get it done")
           end
         end
 
@@ -227,20 +230,20 @@ module WorkerRoulette
       end
     end
 
-    pending "should return a hash with a string in the payload if OJ cannot parse the json"
+    pending "returns a hash with a string in the payload if OJ cannot parse the json"
 
     context "Failure" do
-      it "should not put the sender_id and work_orders back if processing fails bc new work_orders may have been processed while that process failed" do; done; end
+      it "does not put the sender_id and work_orders back if processing fails bc new work_orders may have been processed while that process failed" do; done; end
     end
 
     context "Concurrent Access" do
-      it "should not leak connections"
+      it "does not leak connections"
 
-      it "should be fork() proof" do
-        @subject = worker_roulette.tradesman
-        @subject.work_orders! do
+      it "is fork() proof" do
+        @tradesman = worker_roulette.tradesman
+        @tradesman.work_orders! do
           fork do
-            @subject.work_orders!
+            @tradesman.work_orders!
           end
         end
         done(1)

--- a/spec/unit/evented_readlock_spec.rb
+++ b/spec/unit/evented_readlock_spec.rb
@@ -8,7 +8,7 @@ module WorkerRoulette
     let(:work_orders)              { "hellot" }
     let(:lock_key)                 { "L*:#{sender}" }
     let(:queued_at)                { 1234567 }
-    let(:default_headers)          { Hash["headers" => { "sender" => sender, "queued_at" => queued_at }] }
+    let(:default_headers)          { Hash["headers" => { "sender" => sender, "queued_at" => (queued_at.to_f * 1_000_000).to_i }] }
     let(:work_orders_with_headers) { default_headers.merge({ "payload" => work_orders }) }
     let(:worker_roulette)          { WorkerRoulette.start(evented: true) }
     let(:foreman1)                 { worker_roulette.foreman(sender) }
@@ -19,7 +19,7 @@ module WorkerRoulette
     subject(:tradesman) {worker_roulette.tradesman}
 
     em_before do
-      allow_any_instance_of(Time).to receive(:now).and_return(queued_at)
+      allow(Time).to receive(:now).and_return(queued_at)
       lua.clear_cache!
       redis.script(:flush)
       redis.flushdb

--- a/spec/unit/preprocessor_spec.rb
+++ b/spec/unit/preprocessor_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+describe WorkerRoulette::Preprocessor do
+  before { allow(subject).to receive(:preprocessors).and_return(preprocessors) }
+
+  class TestClass
+    include WorkerRoulette::Preprocessor
+    def preprocessors
+    end
+  end
+
+  module TestPreprocessor
+    class TestClass
+      def process(job, channel)
+      end
+    end
+  end
+
+  describe "#preprocess" do
+    let(:wo) { double("work_order") }
+    let(:result) { double("resulting_wo") }
+    let(:channel) { "aChannel" }
+    subject { TestClass.new }
+
+    context "with one preprocessor" do
+      let(:preprocessors) { [TestPreprocessor] }
+
+      it "calls the correct preprocessor with the correct args" do
+        expect_any_instance_of(TestPreprocessor::TestClass).to receive(:process).with(wo, channel)
+        subject.preprocess(wo, channel)
+      end
+
+      it "returns the value of the preprocessor" do
+        allow_any_instance_of(TestPreprocessor::TestClass).to receive(:process).and_return(result)
+        expect(subject.preprocess(wo, channel)).to eq(result)
+      end
+    end
+
+    context "with two preprocessors" do
+      let(:preprocessors) { [TestPreprocessor, TestPreprocessor] }
+      let(:intermediate) { double("intermediate_result") }
+
+      it "chains the preprocessors and returns the correct result" do
+        allow_any_instance_of(TestPreprocessor::TestClass).to receive(:process).with(wo, channel).and_return(intermediate)
+        allow_any_instance_of(TestPreprocessor::TestClass).to receive(:process).with(intermediate, channel).and_return(result)
+
+        expect(subject.preprocess(wo, channel)).to eq(result)
+      end
+    end
+  end
+end

--- a/spec/unit/queue_latency_tracker_spec.rb
+++ b/spec/unit/queue_latency_tracker_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+module QueueLatencyTracker
+  describe ".configure" do
+    let(:source_config) { { logstash_server_ip: ip, logstash_port: port, server_name: server_name } }
+    let(:ip)            { "1.2.3.4" }
+    let(:port)          { 123 }
+    let(:server_name)   { "server.example" }
+
+
+    it "stores the configuration" do
+      QueueLatencyTracker.configure(source_config)
+
+      expect(QueueLatencyTracker.config).to eq({
+        logstash: {
+          server_ip: ip,
+          port: port },
+        server_name: server_name
+      })
+    end
+  end
+
+  describe Foreman do
+    describe "#process" do
+      let(:queued_at)      { 1234567 }
+      let(:raw_work_order) { { "headers" => {}, "payload" => "aPayload" } }
+      let(:work_order)     { subject.process(raw_work_order) }
+
+      before { allow(Time).to receive(:now).and_return(queued_at) }
+
+      it "sets queued_at to now using specified granularity" do
+        expect(work_order["headers"]["queued_at"]).to eq(queued_at * GRANULARITY)
+
+      end
+    end
+  end
+
+  describe Tradesman do
+    describe "#process" do
+      let(:queued_at)       { 1234567 * GRANULARITY }
+      let(:expected_json)   { %({"server_name":"#{server_name}","queue_latency (ms)":#{latency * 1000},"channel":"#{channel}"}) }
+      let(:ip)              { "1.2.3.4" }
+      let(:port)            { 123 }
+      let(:latency)         { 123.432 }
+      let(:server_name)     { "server.example" }
+      let(:channel)         { "a_channel" }
+      let(:headers)         { { "queued_at" => queued_at } }
+      let(:raw_work_order)  { { "headers" => headers, "payload" => "aPayload" } }
+      let(:logstash_config) { { server_ip: ip, port: port } }
+      let(:config)          { { logstash: logstash_config, server_name: server_name } }
+
+      before { allow(QueueLatencyTracker).to receive(:config).and_return(config) }
+      before { allow(Time).to receive(:now).and_return(queued_at / GRANULARITY + latency) }
+      before { allow_any_instance_of(UDPSocket).to receive(:send) }
+
+      it "passes the right json to logstash_send" do
+        expect_any_instance_of(UDPSocket).to receive(:send).with(expected_json, 0, ip, port)
+
+        subject.process(raw_work_order, channel)
+      end
+
+      it "returns the work order unchanged" do
+        expect(subject.process(raw_work_order, channel)).to eq(raw_work_order)
+      end
+    end
+  end
+end

--- a/spec/unit/queue_latency_tracker_spec.rb
+++ b/spec/unit/queue_latency_tracker_spec.rb
@@ -22,9 +22,10 @@ module QueueLatencyTracker
 
   describe Foreman do
     describe "#process" do
+      let(:channel)        { "a_channel" }
       let(:queued_at)      { 1234567 }
       let(:raw_work_order) { { "headers" => {}, "payload" => "aPayload" } }
-      let(:work_order)     { subject.process(raw_work_order) }
+      let(:work_order)     { subject.process(raw_work_order, channel) }
 
       before { allow(Time).to receive(:now).and_return(queued_at) }
 

--- a/spec/unit/readlock_spec.rb
+++ b/spec/unit/readlock_spec.rb
@@ -1,70 +1,72 @@
-require 'spec_helper'
+require "spec_helper"
+
 module WorkerRoulette
  describe "Read Lock" do
-    let(:worker_roulette) {WorkerRoulette.start(evented: false)}
-    let(:redis) {Redis.new(worker_roulette.redis_config)}
-    let(:sender) {'katie_80'}
-    let(:work_orders) {"hellot"}
-    let(:lock_key) {"L*:#{sender}"}
-    let(:default_headers) {Hash['headers' => {'sender' => sender}]}
-    let(:work_orders_with_headers) {default_headers.merge({'payload' => work_orders})}
-    let(:jsonized_work_orders_with_headers) {[WorkerRoulette.dump(work_orders_with_headers)]}
-    let(:foreman) {worker_roulette.foreman(sender)}
-    let(:number_two) {worker_roulette.foreman('number_two')}
-    let(:subject) {worker_roulette.tradesman}
-    let(:subject_two) {worker_roulette.tradesman}
-    let(:lua) { Lua.new(worker_roulette.tradesman_connection_pool) }
+    let(:worker_roulette)          { WorkerRoulette.start(evented: false) }
+    let(:redis)                    { Redis.new(worker_roulette.redis_config) }
+    let(:sender)                   { "katie_80" }
+    let(:work_orders)              { "hello" }
+    let(:lock_key)                 { "L*:#{sender}" }
+    let(:queued_at)                { 1234567 }
+    let(:default_headers)          { Hash["headers" => { "sender" => sender, "queued_at" => Time.now.to_i }] }
+    let(:work_orders_with_headers) { default_headers.merge({ "payload" => work_orders }) }
+    let(:foreman1)                 { worker_roulette.foreman(sender) }
+    let(:foreman2)                 { worker_roulette.foreman("foreman2") }
+    let(:lua)                      { Lua.new(worker_roulette.tradesman_connection_pool) }
+    let(:tradesman_1)              { worker_roulette.tradesman }
+    let(:tradesman_2)              { worker_roulette.tradesman }
 
     before do
       lua.clear_cache!
       redis.script(:flush)
       redis.flushdb
-      foreman.enqueue_work_order(work_orders)
-      expect(subject.work_orders!).to eq([work_orders_with_headers])
+      allow_any_instance_of(Time).to receive(:now).and_return(queued_at)
+      foreman1.enqueue_work_order(work_orders)
+      expect(tradesman_1.work_orders!).to eq([work_orders_with_headers])
     end
 
-    it "should lock a queue when it reads from it" do
+    it "locks a queue when it reads from it" do
       expect(redis.get(lock_key)).not_to be_nil
     end
 
-    it "should set the lock to expire in 3 second" do
+    it "sets the lock to expire in 3 seconds" do
       expect(redis.ttl(lock_key)).to eq(3)
     end
 
-    it "should not read a locked queue" do
-      foreman.enqueue_work_order(work_orders)    #locked
-      expect(subject_two.work_orders!).to be_empty
+    it "does not read a locked queue" do
+      foreman1.enqueue_work_order(work_orders)    #locked
+      expect(tradesman_2.work_orders!).to be_empty
     end
 
-    it "should read from the first available queue that is not locked" do
-       foreman.enqueue_work_order(work_orders)     #locked
-       number_two.enqueue_work_order(work_orders)  #unlocked
-       expect(subject_two.work_orders!.first['headers']['sender']).to eq('number_two')
+    it "reads from the first available queue that is not locked" do
+       foreman1.enqueue_work_order(work_orders)     #locked
+       foreman2.enqueue_work_order(work_orders)  #unlocked
+       expect(tradesman_2.work_orders!.first["headers"]["sender"]).to eq("foreman2")
     end
 
-    it "should release its previous lock when it asks for work from another sender" do
-      number_two.enqueue_work_order(work_orders)    #unlocked
-      expect(subject.last_sender).to eq(sender)
-      expect(subject.work_orders!.first['headers']['sender']).to eq('number_two')
+    it "releases its previous lock when it asks for work from another sender" do
+      foreman2.enqueue_work_order(work_orders)    #unlocked
+      expect(tradesman_1.last_sender).to eq(sender)
+      expect(tradesman_1.work_orders!.first["headers"]["sender"]).to eq("foreman2")
       expect(redis.get(lock_key)).to be_nil
     end
 
-    it "should not release its lock when it asks for work from the same sender" do
-      foreman.enqueue_work_order(work_orders)    #locked
-      expect(subject.work_orders!).to eq([work_orders_with_headers])
-      expect(subject.last_sender).to eq(sender)
+    it "does not release its lock when it asks for work from the same sender" do
+      foreman1.enqueue_work_order(work_orders)    #locked
+      expect(tradesman_1.work_orders!).to eq([work_orders_with_headers])
+      expect(tradesman_1.last_sender).to eq(sender)
 
-      foreman.enqueue_work_order(work_orders)    #locked
-      expect(subject.work_orders!).to eq([work_orders_with_headers])
-      expect(subject.last_sender).to eq(sender)
+      foreman1.enqueue_work_order(work_orders)    #locked
+      expect(tradesman_1.work_orders!).to eq([work_orders_with_headers])
+      expect(tradesman_1.last_sender).to eq(sender)
 
       expect(redis.get(lock_key)).not_to be_nil
     end
 
-    it "should release its previous lock if there is no work to do from the same sender" do
-      foreman.enqueue_work_order(work_orders)    #locked
-      expect(subject.work_orders!).to eq([work_orders_with_headers])
-      expect(subject.work_orders!).to be_empty
+    it "releases its previous lock if there is no work to do from the same sender" do
+      foreman1.enqueue_work_order(work_orders)    #locked
+      expect(tradesman_1.work_orders!).to eq([work_orders_with_headers])
+      expect(tradesman_1.work_orders!).to be_empty
       expect(redis.get(lock_key)).to be_nil
     end
   end

--- a/spec/unit/readlock_spec.rb
+++ b/spec/unit/readlock_spec.rb
@@ -8,7 +8,7 @@ module WorkerRoulette
     let(:work_orders)              { "hello" }
     let(:lock_key)                 { "L*:#{sender}" }
     let(:queued_at)                { 1234567 }
-    let(:default_headers)          { Hash["headers" => { "sender" => sender, "queued_at" => Time.now.to_i }] }
+    let(:default_headers)          { Hash["headers" => { "sender" => sender, "queued_at" => (queued_at.to_f * 1_000_000).to_i }] }
     let(:work_orders_with_headers) { default_headers.merge({ "payload" => work_orders }) }
     let(:foreman1)                 { worker_roulette.foreman(sender) }
     let(:foreman2)                 { worker_roulette.foreman("foreman2") }
@@ -20,7 +20,7 @@ module WorkerRoulette
       lua.clear_cache!
       redis.script(:flush)
       redis.flushdb
-      allow_any_instance_of(Time).to receive(:now).and_return(queued_at)
+      allow(Time).to receive(:now).and_return(queued_at)
       foreman1.enqueue_work_order(work_orders)
       expect(tradesman_1.work_orders!).to eq([work_orders_with_headers])
     end


### PR DESCRIPTION
This PR simply adds queued_at to the default headers for use by consumers who want to know how long a message has been in a WR queue.

* added queued_at (Time.now.nsec) into the headers by the foreman who enqueues the message
* lots of refactors to increase readability of the specs